### PR TITLE
Analytics tracking improvements (closeNutshell, idle, scroll-depth)

### DIFF
--- a/README-ANALYTICS.md
+++ b/README-ANALYTICS.md
@@ -17,16 +17,34 @@ PostHog is initialized with `persistence: 'memory'` and `person_profiles: 'ident
 
 | Event | Trigger | Properties |
 | :--- | :--- | :--- |
-| `read` | User scrolls past 50% of page | `page` |
+| `read25` / `read50` / `read75` | Viewport bottom crosses 25% / 50% / 75% of page | `page`, `read_id`, `page_height` |
 | `openNutshell` | Nutshell expandable link opened | `page`, `text` |
-| `closeNutshell` | Nutshell link closed after being opened | `text`, `duration` |
-| `inactiveNutshell` | Nutshell bubble scrolled out of viewport while open | `text`, `duration` |
+| `closeNutshell` | Nutshell manually closed (click text or X button) | `text` ("x" or nutshell text), `duration` |
+| `inactiveNutshell` | Nutshell scrolled out of viewport while open | `text`, `duration` |
 | `openQuiz` | `<details>` element expanded | `page`, `text` |
 | `closeQuiz` | `<details>` element collapsed | `page`, `text`, `duration` |
-| `internalLinkClick` | Click on any internal `<a>` (non-nutshell) | `text`, `link` |
-| `externalLinkClick` | Click on any external `<a>` (non-nutshell) | `text`, `link` |
+| `internalLinkClick` | Click on internal `<a>` (non-nutshell) | `text`, `link` |
+| `externalLinkClick` | Click on external `<a>` (non-nutshell) | `text`, `link` |
+| `tabFocused` | Tab gains focus / initial visible state | `isInitial`, `page`, `totalTimeOpen`, `timeHidden` |
+| `tabUnfocused` | Tab loses focus | `isInitial`, `page`, `totalTimeOpen`, `timeFocused` |
+| `userIdle` | 5 minutes of zero input | `page`, `idle_id` |
+| `userActive` | User returns after being idle | `page`, `idle_id`, `idle_duration` |
 
 Duration values are in milliseconds, calculated from a `data-open-time` attribute set when the element opens.
+
+## Changes (edits-2026)
+
+| Change | New or updated? | What it does |
+| :--- | :--- | :--- |
+| Page-load setup | Updated | Now also begins tab-focus tracking as soon as the page loads. |
+| Tab focus / away detection | New | Records when a student switches to or away from the course website tab, and how long they were away. |
+| Nutshell close (click text) | Updated | Closing a nutshell by clicking its text is now logged as a manual close, separate from auto-close. |
+| Nutshell close (X button) | New | Logs when a student closes a nutshell using the X button. |
+| Nutshell link setup | Updated | Stops duplicate generic click records on nutshell links. |
+| Regular link setup | Updated | Stops duplicate generic click records on normal page links. |
+| Quiz/dropdown setup | Updated | Stops duplicate generic click records on quiz dropdown menus. |
+| Scroll / reading depth | Updated | Reading tracked at 25%, 50%, and 75% down the page (previously only one mark at 50%). |
+| Idle detection | New | Detects when a student stops interacting (idle) and logs when they become active again. |
 
 ## Key Files
 

--- a/src/components/DateAnalyticsComponent.astro
+++ b/src/components/DateAnalyticsComponent.astro
@@ -49,10 +49,11 @@ import posthog from "posthog-js";
           persistence: 'memory',
           person_profiles: 'identified_only',
         });
-          posthog.identify(user.id, {
-            name: user.username,
-            timestamp: new Date().toISOString()
-          });
+        setupVisibilityTracking();
+        posthog.identify(user.id, {
+          name: user.username,
+          timestamp: new Date().toISOString()
+        });
       } catch (error) {
         console.error('Error initializing tracking:', error);
       }
@@ -66,8 +67,57 @@ import posthog from "posthog-js";
     // Usage
     initialize();
 
+    function setupVisibilityTracking() {  
+      let lastVisChange = Date.now() // from current state
+      const pageOpenedAt = Date.now();
+
+      // If the tab is visible/hidden upon load
+      if (document.visibilityState === 'visible') {
+        posthog.capture('tabFocused', {
+          isInitial: true,
+          page: document.title,
+          totalTimeOpen: 0,
+          timeHidden: 0
+        })
+      }
+      else {
+        posthog.capture('tabUnfocused', {
+          isInitial: true,
+          page: document.title,
+          totalTimeOpen: 0,
+          timeFocused: 0
+        })
+      }
+      document.addEventListener('visibilitychange', () => {
+        const now = Date.now()
+        const elapsedMs = now - lastVisChange
+        const currOpenedMs = now - pageOpenedAt
+        
+        // If the tab is currently focused
+        if (document.visibilityState === 'visible') {
+          posthog.capture('tabFocused', {
+            isInitial: false,
+            page: document.title,
+            totalTimeOpen: currOpenedMs,
+            timeHidden: elapsedMs
+          })
+        }
+        // If tab is currently hidden 
+        else {
+          posthog.capture('tabUnfocused', {
+            isInitial: false,
+            page: document.title,
+            totalTimeOpen: currOpenedMs, 
+            timeFocused: elapsedMs,
+          })
+        }
+        lastVisChange = now
+      })
+    }
+
+
     window.addEventListener("load", function () {
-    let readEventTriggered = false;
+      let scroll25, scroll50, scroll75 = false;
 
     const documentDetailObserver = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
@@ -77,6 +127,7 @@ import posthog from "posthog-js";
             newDetailsElements.forEach((details) => {
               const summary = details.querySelector("summary");
               if (summary) {
+                summary.classList.add("ph-no-autocapture")
                 summary.addEventListener("click", () => {
                       if (!details.open) {
                         posthog.capture("openQuiz", {
@@ -116,6 +167,7 @@ import posthog from "posthog-js";
       link.removeAttribute("data-open-time");
     }
 
+    // Clicks on the nutshell text/link 
     function handleNutshellClick(event: Event) {
       const link = event.currentTarget as HTMLAnchorElement;
       const currentMode = link.getAttribute("mode");
@@ -152,10 +204,19 @@ import posthog from "posthog-js";
           ".nutshell-bubble"
         ) as HTMLElement;
         if (nutshellBubble) {
+          nutshellBubble.classList.add("ph-no-autocapture")
           nutshellObserver.observe(nutshellBubble);
         }
-      } else if (currentMode === "closed") {
-        handleNutshellInactive(link);
+      } 
+      // Nutshell manually closed 
+      else if (currentMode === "closed") {
+        const openTime = parseInt(link.getAttribute("data-open-time") || "0");
+        if (openTime == "0") return;
+        const duration = Date.now() - openTime
+        posthog.capture("closeNutshell", {
+          text: link.textContent,
+          duration: duration,
+      })
         const nutshellBubble = document.querySelector(
           ".nutshell-bubble"
         ) as HTMLElement;
@@ -165,10 +226,30 @@ import posthog from "posthog-js";
       }
     }
 
+    // Clicks on open nutshell's x button
+    function handleNutshellXClick(event: Event) {
+      const xButton = (event.target as HTMLElement).closest(".nutshell-bubble-overflow-close")
+      if (!xButton) return;
+      const nutshellBubble = xButton.closest(".nutshell-bubble") as HTMLElement
+      const nutshellLink = nutshellBubble.previousElementSibling?.previousSibling as HTMLAnchorElement
+      if (!nutshellLink) return;
+      const openTime = parseInt(nutshellLink.getAttribute("data-open-time") || "0")
+      if (openTime == 0) return;
+      const duration = Date.now() - openTime;
+      posthog.capture("closeNutshell", {
+        text: nutshellLink.textContent,
+        duration: duration,
+      })
+      nutshellLink.removeAttribute("data-open-time")
+    } 
+
+    document.addEventListener("click", handleNutshellXClick);
+
     function addNutshellListener(link: HTMLAnchorElement) {
       if (!link.hasAttribute("listener-added")) {
         link.addEventListener("click", handleNutshellClick);
         link.setAttribute("listener-added", "true");
+        link.classList.add("ph-no-autocapture")
       }
     }
 
@@ -191,6 +272,7 @@ import posthog from "posthog-js";
       ) {
         link.addEventListener("click", handleLinkClick);
         link.setAttribute("link-listener-added", "true");
+        link.classList.add("ph-no-autocapture")
       }
     }
 
@@ -237,19 +319,80 @@ import posthog from "posthog-js";
   threshold: 0,
 });
 
-
+    // read25, read50, read75
     function handleScroll() {
-      if (!readEventTriggered) {
-        const scrollPosition = window.scrollY + window.innerHeight;
-        const totalHeight = document.documentElement.scrollHeight;
+      const scrollPosition = window.scrollY + window.innerHeight;
+      const totalHeight = document.documentElement.scrollHeight;
+      let idleId: string | null = null;
 
-        if (scrollPosition >= totalHeight / 2) {
-          posthog.capture("read", { page: document.title });
-          readEventTriggered = true;
-          window.removeEventListener("scroll", handleScroll);
-        }
+      if (!scroll25 && scrollPosition >= totalHeight * 0.25) {
+        posthog.capture("read25", { 
+          page: document.title,
+          read_id: crypto.randomUUID(),
+          page_height: totalHeight 
+        });
+        scroll25 = true;
+      }
+      if (!scroll50 && scrollPosition >= totalHeight * 0.5) {
+        posthog.capture("read50", { 
+          page: document.title,
+          read_id: crypto.randomUUID(),
+          page_height: totalHeight  
+        });
+        scroll50 = true;
+      }
+      if (!scroll75 && scrollPosition >= totalHeight * 0.75) {
+        posthog.capture("read75", { 
+          page: document.title,
+          read_id: crypto.randomUUID(),
+          page_height: totalHeight   
+        });
+        scroll75 = true;
       }
     }
+
+
+    // Adding userIdle/userStillIdle/userActive
+    let idleTimer: ReturnType<typeof setTimeout>;
+    let stillIdleTimer: ReturnType<typeof setInterval>;
+    let idleFired = false
+    let idleId: string | null = null;
+    let idlePeriodStarted = 0;
+
+    const IDLE_MS = 1 * 60 * 1000;    // 5min
+    
+    function resetIdleTimer() {
+      clearTimeout(idleTimer);
+      clearInterval(stillIdleTimer);
+
+      if (idleFired) {
+        posthog.capture("userActive", {
+          page: document.title,
+          idle_id: idleId,
+          idle_duration: (Date.now() - idlePeriodStarted) / 1000
+        });
+        idleFired = false
+        idleId = null
+      }
+      idleTimer = setTimeout(() => {
+        idleId = crypto.randomUUID()
+        idlePeriodStarted = Date.now()
+        posthog.capture('userIdle', {
+          page: document.title,
+          idle_id: idleId
+        });
+        idleFired = true;
+        stillIdleTimer = setInterval(() => {
+          posthog.capture('userIdle', {
+            page: document.title,
+            idle_id: idleId
+          });
+        }, IDLE_MS)
+      }, IDLE_MS)
+    }
+    // Events that would reset idle time
+    ['mousemove', 'mousedown', 'click', 'keydown', 'scroll', 'touchstart'].forEach(event => document.addEventListener(event, resetIdleTimer, { passive: true }))
+
 
     addInitialListeners();
     window.addEventListener("scroll", handleScroll);

--- a/src/components/DateAnalyticsComponent.astro
+++ b/src/components/DateAnalyticsComponent.astro
@@ -72,22 +72,13 @@ import posthog from "posthog-js";
       const pageOpenedAt = Date.now();
 
       // If the tab is visible/hidden upon load
-      if (document.visibilityState === 'visible') {
-        posthog.capture('tabFocused', {
-          isInitial: true,
-          page: document.title,
-          totalTimeOpen: 0,
-          timeHidden: 0
-        })
-      }
-      else {
-        posthog.capture('tabUnfocused', {
-          isInitial: true,
-          page: document.title,
-          totalTimeOpen: 0,
-          timeFocused: 0
-        })
-      }
+      const visible = document.visibilityState === 'visible';
+      posthog.capture(visible ? 'tabFocused' : 'tabUnfocused', {
+        isInitial: true,
+        page: document.title,
+        totalTimeOpen: 0,
+        [visible ? 'timeHidden' : 'timeFocused']: 0,
+      });
       document.addEventListener('visibilitychange', () => {
         const now = Date.now()
         const elapsedMs = now - lastVisChange
@@ -117,7 +108,7 @@ import posthog from "posthog-js";
 
 
     window.addEventListener("load", function () {
-      let scroll25, scroll50, scroll75 = false;
+      let scroll25 = false, scroll50 = false, scroll75 = false;
 
     const documentDetailObserver = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
@@ -167,6 +158,16 @@ import posthog from "posthog-js";
       link.removeAttribute("data-open-time");
     }
 
+    function captureNutshellClose(link: HTMLAnchorElement, method: "text" | "x") {
+      const openTime = parseInt(link.getAttribute("data-open-time") || "0");
+      if (openTime === 0) return;
+      posthog.capture("closeNutshell", {
+        text: method === "x" ? "x" : link.textContent,
+        duration: Date.now() - openTime,
+      });
+      link.removeAttribute("data-open-time");
+    }
+
     // Clicks on the nutshell text/link 
     function handleNutshellClick(event: Event) {
       const link = event.currentTarget as HTMLAnchorElement;
@@ -210,13 +211,7 @@ import posthog from "posthog-js";
       } 
       // Nutshell manually closed 
       else if (currentMode === "closed") {
-        const openTime = parseInt(link.getAttribute("data-open-time") || "0");
-        if (openTime == "0") return;
-        const duration = Date.now() - openTime
-        posthog.capture("closeNutshell", {
-          text: link.textContent,
-          duration: duration,
-      })
+        captureNutshellClose(link, "text");
         const nutshellBubble = document.querySelector(
           ".nutshell-bubble"
         ) as HTMLElement;
@@ -233,14 +228,7 @@ import posthog from "posthog-js";
       const nutshellBubble = xButton.closest(".nutshell-bubble") as HTMLElement
       const nutshellLink = nutshellBubble.previousElementSibling?.previousSibling as HTMLAnchorElement
       if (!nutshellLink) return;
-      const openTime = parseInt(nutshellLink.getAttribute("data-open-time") || "0")
-      if (openTime == 0) return;
-      const duration = Date.now() - openTime;
-      posthog.capture("closeNutshell", {
-        text: nutshellLink.textContent,
-        duration: duration,
-      })
-      nutshellLink.removeAttribute("data-open-time")
+      captureNutshellClose(nutshellLink, "x");
     } 
 
     document.addEventListener("click", handleNutshellXClick);
@@ -323,7 +311,6 @@ import posthog from "posthog-js";
     function handleScroll() {
       const scrollPosition = window.scrollY + window.innerHeight;
       const totalHeight = document.documentElement.scrollHeight;
-      let idleId: string | null = null;
 
       if (!scroll25 && scrollPosition >= totalHeight * 0.25) {
         posthog.capture("read25", { 
@@ -359,7 +346,7 @@ import posthog from "posthog-js";
     let idleId: string | null = null;
     let idlePeriodStarted = 0;
 
-    const IDLE_MS = 1 * 60 * 1000;    // 5min
+    const IDLE_MS = 5 * 60 * 1000; // 5 minutes
     
     function resetIdleTimer() {
       clearTimeout(idleTimer);


### PR DESCRIPTION
## Summary

Analytics tracking improvements from the SRIP 2026 work, plus bug fixes verified by `astro check` (0 errors).

## What changed

| Change | New or updated? | What it does |
| :--- | :--- | :--- |
| Page-load setup | Updated | Now also begins tab-focus tracking as soon as the page loads. |
| Tab focus / away detection | New | Records when a student switches to or away from the course website tab, and how long they were away. |
| Nutshell close (click text) | Updated | Closing a nutshell by clicking its text is now logged as a manual close, separate from auto-close. |
| Nutshell close (X button) | New | Logs when a student closes a nutshell using the X button. |
| Nutshell link setup | Updated | Stops duplicate generic click records on nutshell links. |
| Regular link setup | Updated | Stops duplicate generic click records on normal page links. |
| Quiz/dropdown setup | Updated | Stops duplicate generic click records on quiz dropdown menus. |
| Scroll / reading depth | Updated | Reading tracked at 25%, 50%, and 75% down the page (previously only one mark at 50%). |
| Idle detection | New | Detects when a student stops interacting (idle) and logs when they become active again. |

## Bug fixes included

- `closeNutshell` x-click now sends `text="x"` (was sending the nutshell text).
- Added missing `removeAttribute("data-open-time")` on text-click close.
- Removed dead `idleId` variable inside `handleScroll`.
- Initialized all `scroll25` / `scroll50` / `scroll75` flags (was only `scroll75`).
- Set `IDLE_MS` to 5 minutes (was 1 minute).
- Collapsed the initial tab focus/unfocus capture into a single call.

## Verification

`pnpm exec astro check` → 0 errors, 0 warnings for the analytics component.

## Docs

`README-ANALYTICS.md` updated: Tracked Events table refreshed to match current code; new **Changes (edits-2026)** section added.
